### PR TITLE
Add --exclude-paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
           name: install rust
           command: 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && cargo version'
       - run:
+          name: prepare venv
+          command: 'make -C test/ venv'
+      - run:
           name: test
-          command: 'make -C test/ circle-ci'
+          command: 'make -C test/ circle-ci-integration-test'
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
- "yaml-rust",
 ]
 
 [[package]]
@@ -286,9 +285,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 walkdir = "2"
 regex = "1"
 lazy_static = "1.4.0"
-clap = {version = "~2.27.0", features = ["yaml"]}
+clap = "~2.27.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sys-info = "0.5.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ extern crate regex;
 use walkdir::{WalkDir, DirEntry};
 use clap::{Arg, App};
 use crate::common::scanner::LibScannerExt;
+use std::fs;
+use std::path::PathBuf;
 
 mod scanner;
 mod common;
@@ -23,14 +25,34 @@ fn main() {
             .help("Which dir to scan recursively")
             .takes_value(true)
             .required(true))
+        .arg(Arg::with_name("exclude")
+            .short("e")
+            .long("exclude-dir")
+            .value_name("DIR")
+            .takes_value(true)
+            .multiple(true))
         .get_matches();
 
     let dir = matches.value_of("dir").unwrap();
+    let mut excluded_dirs:Vec<String>= Vec::new();
+    if let Some(excluded) = matches.values_of("exclude") {
+        for exclude in excluded.into_iter() {
+            excluded_dirs.push(
+                String::from(fs::canonicalize(PathBuf::from(exclude))
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+                )
+            );
+        }
+    }
 
     // collect list of all files
     let metadata_files:Vec<DirEntry> = WalkDir::new(dir)
         .follow_links(false)
         .into_iter()
+        .filter_entry(|e|!is_excluded_dir(e, &excluded_dirs))
         .filter_map(|v| v.ok())
         .collect();
 
@@ -50,4 +72,8 @@ fn main() {
     // TODO: scan golang packages
     // TODO: scan files for nodejs packages
     // TODO: scan ruby gems
+}
+
+fn is_excluded_dir(dir: &DirEntry, excluded_dirs: &Vec<String>) -> bool {
+    excluded_dirs.contains(&dir.path().to_str().unwrap().to_string())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,14 +37,11 @@ fn main() {
     let mut excluded_dirs:Vec<String>= Vec::new();
     if let Some(excluded) = matches.values_of("exclude") {
         for exclude in excluded.into_iter() {
-            excluded_dirs.push(
-                String::from(fs::canonicalize(PathBuf::from(exclude))
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .to_string()
-                )
-            );
+            let os_dir = fs::canonicalize(PathBuf::from(exclude));
+            match os_dir {
+                Ok(os_dir) => excluded_dirs.push(String::from(os_dir.to_str().unwrap())),
+                _ => (),
+            }
         }
     }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,4 +2,4 @@ circle-ci:
 	mkdir -p ./.venv
 	virtualenv ./.venv
 	. .venv/bin/activate; pip install -r requirements.txt
-	cargo run --color=always -- -e /proc/ -e /sys/ -e /dev/ -d / | tee /dev/tty | grep "/home/circleci/project/test/.venv/lib/python3.6/site-packages/Pipfile.lock"
+	cargo run --color=always -- -e /proc/ -e /sys/ -e /dev/ -e /does-not-exist -d / | tee /dev/tty | grep "/home/circleci/project/test/.venv/lib/python3.6/site-packages/Pipfile.lock"

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,4 +2,4 @@ circle-ci:
 	mkdir -p ./.venv
 	virtualenv ./.venv
 	. .venv/bin/activate; pip install -r requirements.txt
-	cargo run --color=always -- -d ${HOME} | tee /dev/tty | grep "/home/circleci/project/test/.venv/lib/python3.6/site-packages/Pipfile.lock"
+	cargo run --color=always -- -e /proc/ -e /sys/ -e /dev/ -d / | tee /dev/tty | grep "/home/circleci/project/test/.venv/lib/python3.6/site-packages/Pipfile.lock"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,7 @@
-circle-ci:
+venv:
 	mkdir -p ./.venv
 	virtualenv ./.venv
 	. .venv/bin/activate; pip install -r requirements.txt
+
+circle-ci-integration-test:
 	cargo run --color=always -- -e /proc/ -e /sys/ -e /dev/ -e /does-not-exist -d / | tee /dev/tty | grep "/home/circleci/project/test/.venv/lib/python3.6/site-packages/Pipfile.lock"


### PR DESCRIPTION
Allow paths to be excluded from scans. Useful to exclude data disks on DB VMs (amongst others).